### PR TITLE
gtmhub get now display the help

### DIFF
--- a/commands/get.go
+++ b/commands/get.go
@@ -6,7 +6,6 @@ var (
 	GetCommand = &cli.Command{
 		Name:  "get",
 		Usage: "gets you items from gtmhub",
-		Action: ListAction,
 		Subcommands: []*cli.Command{
 			ListCommand,
 			KRsCommand,


### PR DESCRIPTION
Previously the gtmhub get command would execute the ListAction by default. Now the command will correctly display the help for the get option.

fixes #9 