### PR TITLE
adding a step that builds and pushes a choco pack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,8 @@ jobs:
 
       - name: Copy Binaries
         run: copy release\windows\gtmhub.exe build\chocolatey\tools\gtmhub.exe
+      - name: Copy License
+        run: copy LICENSE build\chocolatey\tools\LICENSE.txt
       - name: choco pack
         run: choco pack build\chocolatey\gtmhub-cli.nuspec --version ${{ github.event.inputs.version }}
       - name: push the choco pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,25 @@ jobs:
           userName: ${{ secrets.HOMEBREW_UPDATE_USERNAME }}
           tapRepo: "gtmhub/homebrew-gtmhub"
           srcRepo: "gtmhub/gtmhub-cli"
+  update-choco-package:
+    runs-on: windows-latest
+    needs: [release]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Download-Binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: binaries
+          path: release/
+
+      - name: Copy Binaries
+        run: copy release\windows\gtmhub.exe build\chocolatey\tools\gtmhub.exe
+      - name: choco pack
+        run: choco pack build\chocolatey\gtmhub-cli.nuspec --version ${{ github.event.inputs.version }}
+      - name: push the choco pack
+        run: choco push gtmhub-cli.${{github.event.inputs.version}}.nupkg --api-key ${{ secrets.CHOCO_API_KEY }} --source https://push.chocolatey.org/
   generate-release-notes:
     runs-on: ubuntu-latest
     needs: [release]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Gtmhub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/build/chocolatey/gtmhub-cli.nuspec
+++ b/build/chocolatey/gtmhub-cli.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>gtmhub-cli</id>
+    <version>0.1.5</version>
+    <title>Gtmhub CLI</title>
+    <authors>Gtmhub</authors>
+    <projectUrl>https://github.com/gtmhub/gtmhub-cli</projectUrl>
+    <tags>gtmhub-cli</tags>
+    <summary>A command line interface tool intended to work with gtmhub.</summary>
+    <description>no description yet</description>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>


### PR DESCRIPTION
This is a new step to the release workflow that downloads the intermediate output of the build step and packages it as a chocolatey pack and pushes it to the official repo.
Later the pack can be installed on windows using:

`choco install gtmhub-cli --version 0.1.6`

Look into it and approve it but dont merge it yet as our choco repo is pending approval still.